### PR TITLE
Example code now calls `unwrap()` on start/stop

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ This will save the profile to a file you specify.
 ```rust
 use cpuprofiler::PROFILER;
 
-PROFILER.lock().unwrap().start("./my-prof.profile");
+PROFILER.lock().unwrap().start("./my-prof.profile").unwrap();
 // Code you want to sample goes here!
-PROFILER.lock().unwrap().stop();
+PROFILER.lock().unwrap().stop().unwrap();
 ```
 
 Now you can just run the code as you would normally. Once complete the profile will be saved to `./my-prof.profile`.


### PR DESCRIPTION
The example code is meant to be temporarily copied into the program being profiled, so `unwrap()` calls aren't an issue. These extra `unwrap` calls are necessary so that the developer isn't left scratching their head when `start` or `stop` functions silently fail.
