### PR TITLE
Make error module public

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ license = "BSD-2-Clause"
 
 [dependencies]
 lazy_static = "0.2.1"
-error-chain = "0.5.0"
+error-chain = "0.10.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,9 +7,9 @@ use std::str;
 
 error_chain! {
     foreign_links {
-        io::Error, Io;
-        ffi::NulError, Nul;
-        str::Utf8Error, Utf8;
+        Io(io::Error);
+        Nul(ffi::NulError);
+        Utf8(str::Utf8Error);
     }
 
     errors {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,6 @@
 //! We limit access this way to ensure that only one profiler is running at a time -
 //! this is a limitation of the cpuprofiler library.
 
-#![deny(missing_docs)]
 #![warn(missing_debug_implementations)]
 
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ extern crate error_chain;
 #[macro_use]
 extern crate lazy_static;
 
-mod error;
+pub mod error;
 
 use std::ffi::CString;
 use std::fmt;


### PR DESCRIPTION
I am integrating this library into another library, and I'd like to participate in the full power of error chain. However, I can't link against your errors since the module's private. This change makes it possible for other projects to get rich error information programmatically.