### PR TITLE
how to run on a library with cargo test

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ PROFILER.lock().unwrap().stop().unwrap();
 
 Now you can just run the code as you would normally. Once complete the profile will be saved to `./my-prof.profile`.
 
+If you are attempting to profile a Rust library under src/lib.rs using integration test from 'cargo test', pass '--verbose' to cargo test and find the name of the binary that cargo generated under './target/'. You'll need it below. 
+
 The final step is the fun part - analyzing the profile!
 
 ### Analyzing the profile
@@ -60,6 +62,12 @@ To analyze the profile we use google's [pprof](https://github.com/google/pprof) 
 
 An old version of this tool is included with the gperftools package. This is the version I have been using but the newer Go version should work too!
 The usage of pprof is well documented in the [cpuprofiler docs](http://goog-perftools.sourceforge.net/doc/cpu_profiler.html).
+
+A simple example: 
+
+```bash
+$ pprof --text ./path/to/binary ./path/to/my-prof.profile
+```
 
 ## The Result
 


### PR DESCRIPTION
shows a simple example of how to test a cargo library (src/lib.src). its not quite as straightforward because its not immediately obvious to the user where cargo makes the binary, but if you pass --verbose to cargo test it will show you. you can pass this binary to pprof and generate nice profiling information even if you are building a rust library and dont have a 'main' program.