### PR TITLE
Use pkg-config to locate libprofiler

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,6 @@ license = "BSD-2-Clause"
 [dependencies]
 lazy_static = "0.2.1"
 error-chain = "0.10.0"
+
+[build-dependencies]
+pkg-config = "0.3"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,12 @@
+extern crate pkg_config;
+
+fn main () {
+    match pkg_config::Config::new().atleast_version("2.0").probe("libprofiler") {
+        Ok(_) => (),
+        Err(_) => {
+            // Old gperftools do not come with a pkg-config file so just rely
+            // on the linker's path.
+            println!("cargo:rustc-link-lib=profiler");
+        },
+    };
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,6 @@ lazy_static! {
     });
 }
 
-#[link(name = "profiler")]
 #[allow(non_snake_case)]
 extern "C" {
     fn ProfilerStart(fname: *const c_char) -> i32;


### PR DESCRIPTION
There is no guarantee that libprofiler is available on "standard"
locations, which means that simply trying to link to it with -lprofiler
is bound to fail.

For example: a user may have installed gperftools under their home
directory, in which case this crate cannot find it.

To resolve this, use pkg-config to locate the library.  This allows
this crate to learn all compiler and linker flags (in particular, -L)
needed to use the libprofiler library.