### PR TITLE
Update lazy_static dependency to version 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,5 @@ readme = "README.md"
 license = "BSD-2-Clause"
 
 [dependencies]
-lazy_static = "0.2.1"
+lazy_static = "1.0"
 error-chain = "0.10.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ license = "BSD-2-Clause"
 
 [dependencies]
 lazy_static = "1.0"
-error-chain = "0.10.0"
+error-chain = "0.12"


### PR DESCRIPTION
Update lazy_static dependency to version 1.0

This patch updates the lazy_static dependency to 1.0. This version is
used by an increasing number of other crates in the ecosystem and so
going with the flow can reduce the number of crates effectively pulled
during compilation of dependent crates.