### PR TITLE
Fix pkg-config on minimal version check

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ lazy_static = "1.0"
 error-chain = "0.12"
 
 [build-dependencies]
-pkg-config = "0.3"
+pkg-config = "0.3.17"


### PR DESCRIPTION
When compiling with -Z minimal-versions, pkg-config is broken because 0.3 is too old